### PR TITLE
Change renderer to Compatibility mode

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -46,3 +46,5 @@ spacebar={
 [rendering]
 
 textures/canvas_textures/default_texture_filter=3
+renderer/rendering_method="gl_compatibility"
+renderer/rendering_method.mobile="gl_compatibility"


### PR DESCRIPTION
Some players have reported that they can't launch the game ([here](https://steamcommunity.com/app/3566610/discussions/0/509577661714099566/) and [here](https://steamcommunity.com/app/3566610/discussions/0/509577661714016931/)), it is probably due to DirectX 12 / Vulkan being required by the "Forward+" mode.

The game is not in 3D nor complex, so switching to compatibility mode will most likely change nothing except improve compatibility.