### PR TITLE
Better options

### DIFF
--- a/globals/global_variables.gd
+++ b/globals/global_variables.gd
@@ -1,5 +1,7 @@
 extends Node2D
 
+var config: ConfigFile
+
 var player_money
 var player_exp
 

--- a/scenes/main_menu.gd
+++ b/scenes/main_menu.gd
@@ -8,11 +8,11 @@ func _ready() -> void:
 
 		var value = config.get_value("Audio", "music", 0)
 		var bus_index = AudioServer.get_bus_index("Music")
-		AudioServer.set_bus_volume_db(bus_index, value)
+		AudioServer.set_bus_volume_db(bus_index, linear_to_db(value))
 
 		value = config.get_value("Audio", "sfx", 0)
 		bus_index = AudioServer.get_bus_index("sfx")
-		AudioServer.set_bus_volume_db(bus_index, value)
+		AudioServer.set_bus_volume_db(bus_index, linear_to_db(value))
 
 		value = config.get_value("Video", "fullscreen", false)
 		if value:

--- a/scenes/main_menu.gd
+++ b/scenes/main_menu.gd
@@ -1,5 +1,26 @@
 extends Node2D
 
+func _ready() -> void:
+	if not GlobalVariables.config:
+		GlobalVariables.config = ConfigFile.new()
+		var config = GlobalVariables.config
+		config.load("user://options.cfg")
+
+		var value = config.get_value("Audio", "music", 0)
+		var bus_index = AudioServer.get_bus_index("Music")
+		AudioServer.set_bus_volume_db(bus_index, value)
+
+		value = config.get_value("Audio", "sfx", 0)
+		bus_index = AudioServer.get_bus_index("sfx")
+		AudioServer.set_bus_volume_db(bus_index, value)
+
+		value = config.get_value("Video", "fullscreen", false)
+		if value:
+			get_window().mode = Window.MODE_FULLSCREEN
+		else:
+			get_window().mode = Window.MODE_WINDOWED
+
+
 func _on_play_pressed():
 	GlobalVariables.current_stage = GlobalVariables.stage.cave
 	GlobalVariables.player_exp = 0

--- a/scenes/options_menu.gd
+++ b/scenes/options_menu.gd
@@ -13,15 +13,12 @@ func _on_button_pressed():
 	get_tree().change_scene_to_file("res://scenes/main_menu.tscn")
 
 
-func _on_h_slider_drag_ended(value_changed):
-	if value_changed == true:
-		var value = $CenterContainer/VBoxContainer/HSlider.value
-		var sfx_index= AudioServer.get_bus_index("Music")
-		AudioServer.set_bus_volume_db(sfx_index, value)
+func _on_slider_value_changed(value: float, bus: StringName) -> void:
+	var bus_index = AudioServer.get_bus_index(bus)
+	if value == -50:
+		AudioServer.set_bus_mute(bus_index, true)
+	else:
+		AudioServer.set_bus_mute(bus_index, false)
+		AudioServer.set_bus_volume_db(bus_index, value)
 
 
-func _on_h_slider_2_drag_ended(value_changed):
-	if value_changed == true:
-		var value = $CenterContainer/VBoxContainer/HSlider2.value
-		var sfx_index= AudioServer.get_bus_index("sfx")
-		AudioServer.set_bus_volume_db(sfx_index, value)

--- a/scenes/options_menu.gd
+++ b/scenes/options_menu.gd
@@ -8,6 +8,11 @@ func _ready():
 	var sfx_index2 = AudioServer.get_bus_index("sfx")
 	var start_value2 = AudioServer.get_bus_volume_db(sfx_index2)
 	$CenterContainer/VBoxContainer/HSlider2.value = start_value2
+	
+	if get_window().mode == Window.MODE_FULLSCREEN:
+		$CenterContainer/VBoxContainer/Label5/Fullscreen.button_pressed = true
+	else:
+		$CenterContainer/VBoxContainer/Label5/Fullscreen.button_pressed = false
 
 func _on_button_pressed():
 	get_tree().change_scene_to_file("res://scenes/main_menu.tscn")

--- a/scenes/options_menu.gd
+++ b/scenes/options_menu.gd
@@ -15,6 +15,11 @@ func _ready():
 		$CenterContainer/VBoxContainer/Label5/Fullscreen.button_pressed = false
 
 func _on_button_pressed():
+	var config = GlobalVariables.config
+	config.set_value("Audio", "music", int($CenterContainer/VBoxContainer/HSlider.value))
+	config.set_value("Audio", "sfx", int($CenterContainer/VBoxContainer/HSlider2.value))
+	config.set_value("Video", "fullscreen", $CenterContainer/VBoxContainer/Label5/Fullscreen.button_pressed)
+	config.save("user://options.cfg")
 	get_tree().change_scene_to_file("res://scenes/main_menu.tscn")
 
 

--- a/scenes/options_menu.gd
+++ b/scenes/options_menu.gd
@@ -3,11 +3,11 @@ extends Node2D
 func _ready():
 	var sfx_index = AudioServer.get_bus_index("Music")
 	var start_value = AudioServer.get_bus_volume_db(sfx_index)
-	$CenterContainer/VBoxContainer/HSlider.value = start_value
+	$CenterContainer/VBoxContainer/HSlider.value = db_to_linear(start_value)
 	
 	var sfx_index2 = AudioServer.get_bus_index("sfx")
 	var start_value2 = AudioServer.get_bus_volume_db(sfx_index2)
-	$CenterContainer/VBoxContainer/HSlider2.value = start_value2
+	$CenterContainer/VBoxContainer/HSlider2.value = db_to_linear(start_value2)
 	
 	if get_window().mode == Window.MODE_FULLSCREEN:
 		$CenterContainer/VBoxContainer/Label5/Fullscreen.button_pressed = true
@@ -16,8 +16,8 @@ func _ready():
 
 func _on_button_pressed():
 	var config = GlobalVariables.config
-	config.set_value("Audio", "music", int($CenterContainer/VBoxContainer/HSlider.value))
-	config.set_value("Audio", "sfx", int($CenterContainer/VBoxContainer/HSlider2.value))
+	config.set_value("Audio", "music", $CenterContainer/VBoxContainer/HSlider.value)
+	config.set_value("Audio", "sfx", $CenterContainer/VBoxContainer/HSlider2.value)
 	config.set_value("Video", "fullscreen", $CenterContainer/VBoxContainer/Label5/Fullscreen.button_pressed)
 	config.save("user://options.cfg")
 	get_tree().change_scene_to_file("res://scenes/main_menu.tscn")
@@ -25,11 +25,7 @@ func _on_button_pressed():
 
 func _on_slider_value_changed(value: float, bus: StringName) -> void:
 	var bus_index = AudioServer.get_bus_index(bus)
-	if value == -50:
-		AudioServer.set_bus_mute(bus_index, true)
-	else:
-		AudioServer.set_bus_mute(bus_index, false)
-		AudioServer.set_bus_volume_db(bus_index, value)
+	AudioServer.set_bus_volume_db(bus_index, linear_to_db(value))
 
 
 func _on_fullscreen_toggled(toggled_on: bool) -> void:

--- a/scenes/options_menu.gd
+++ b/scenes/options_menu.gd
@@ -22,3 +22,8 @@ func _on_slider_value_changed(value: float, bus: StringName) -> void:
 		AudioServer.set_bus_volume_db(bus_index, value)
 
 
+func _on_fullscreen_toggled(toggled_on: bool) -> void:
+	if toggled_on:
+		get_window().mode = Window.MODE_FULLSCREEN
+	else:
+		get_window().mode = Window.MODE_WINDOWED

--- a/scenes/options_menu.tscn
+++ b/scenes/options_menu.tscn
@@ -34,9 +34,8 @@ horizontal_alignment = 1
 [node name="HSlider" type="HSlider" parent="CenterContainer/VBoxContainer"]
 layout_mode = 2
 mouse_default_cursor_shape = 2
-min_value = -15.0
-max_value = 6.0
-step = 3.0
+min_value = -50.0
+max_value = 0.0
 
 [node name="Label4" type="Label" parent="CenterContainer/VBoxContainer"]
 layout_mode = 2
@@ -48,9 +47,8 @@ horizontal_alignment = 1
 [node name="HSlider2" type="HSlider" parent="CenterContainer/VBoxContainer"]
 layout_mode = 2
 mouse_default_cursor_shape = 2
-min_value = -15.0
-max_value = 6.0
-step = 3.0
+min_value = -50.0
+max_value = 0.0
 
 [node name="Button" type="Button" parent="CenterContainer/VBoxContainer"]
 custom_minimum_size = Vector2(200, 0)
@@ -58,6 +56,6 @@ layout_mode = 2
 mouse_default_cursor_shape = 2
 text = "return to main menu"
 
-[connection signal="drag_ended" from="CenterContainer/VBoxContainer/HSlider" to="." method="_on_h_slider_drag_ended"]
-[connection signal="drag_ended" from="CenterContainer/VBoxContainer/HSlider2" to="." method="_on_h_slider_2_drag_ended"]
+[connection signal="value_changed" from="CenterContainer/VBoxContainer/HSlider" to="." method="_on_slider_value_changed" binds= [&"Music"]]
+[connection signal="value_changed" from="CenterContainer/VBoxContainer/HSlider2" to="." method="_on_slider_value_changed" binds= [&"sfx"]]
 [connection signal="pressed" from="CenterContainer/VBoxContainer/Button" to="." method="_on_button_pressed"]

--- a/scenes/options_menu.tscn
+++ b/scenes/options_menu.tscn
@@ -34,8 +34,9 @@ horizontal_alignment = 1
 [node name="HSlider" type="HSlider" parent="CenterContainer/VBoxContainer"]
 layout_mode = 2
 mouse_default_cursor_shape = 2
-min_value = -50.0
-max_value = 0.0
+max_value = 1.0
+step = 0.01
+value = 1.0
 
 [node name="Label4" type="Label" parent="CenterContainer/VBoxContainer"]
 layout_mode = 2
@@ -47,8 +48,9 @@ horizontal_alignment = 1
 [node name="HSlider2" type="HSlider" parent="CenterContainer/VBoxContainer"]
 layout_mode = 2
 mouse_default_cursor_shape = 2
-min_value = -50.0
-max_value = 0.0
+max_value = 1.0
+step = 0.01
+value = 1.0
 
 [node name="Label5" type="Label" parent="CenterContainer/VBoxContainer"]
 layout_mode = 2

--- a/scenes/options_menu.tscn
+++ b/scenes/options_menu.tscn
@@ -50,6 +50,20 @@ mouse_default_cursor_shape = 2
 min_value = -50.0
 max_value = 0.0
 
+[node name="Label5" type="Label" parent="CenterContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 5
+text = "           Fullscreen"
+
+[node name="Fullscreen" type="CheckButton" parent="CenterContainer/VBoxContainer/Label5"]
+layout_mode = 0
+offset_left = 127.0
+offset_top = 1.0
+offset_right = 171.0
+offset_bottom = 25.0
+mouse_default_cursor_shape = 2
+
 [node name="Button" type="Button" parent="CenterContainer/VBoxContainer"]
 custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
@@ -58,4 +72,5 @@ text = "return to main menu"
 
 [connection signal="value_changed" from="CenterContainer/VBoxContainer/HSlider" to="." method="_on_slider_value_changed" binds= [&"Music"]]
 [connection signal="value_changed" from="CenterContainer/VBoxContainer/HSlider2" to="." method="_on_slider_value_changed" binds= [&"sfx"]]
+[connection signal="toggled" from="CenterContainer/VBoxContainer/Label5/Fullscreen" to="." method="_on_fullscreen_toggled"]
 [connection signal="pressed" from="CenterContainer/VBoxContainer/Button" to="." method="_on_button_pressed"]


### PR DESCRIPTION
This PR improve the options :

- Audio :
  - range from 0.0 to 1.0 with a step of 0.01 (use [linear_to_db](https://docs.godotengine.org/en/stable/classes/class_@globalscope.html#class-globalscope-method-linear-to-db) as recommended by @svenar-nl bellow)
  - can be muted (when at minimum)
  - improve code (both sliders with one function)

- Added fullscreen option

- Remember options